### PR TITLE
Added navigation library dependency

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -70,6 +70,7 @@ dependencies {
     implementation "androidx.compose.ui:ui-tooling-preview:$compose_ui_version"
     implementation 'androidx.compose.material:material:1.3.1'
     implementation "androidx.lifecycle:lifecycle-viewmodel-compose:2.5.1"
+    implementation "androidx.navigation:navigation-compose:$nav_version"
 
     androidTestImplementation "androidx.compose.ui:ui-test-junit4:$compose_ui_version"
     debugImplementation "androidx.compose.ui:ui-tooling:$compose_ui_version"

--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ buildscript {
         glideVersion = "4.12.0"
         fragmentVersion = "1.3.6"
         compose_ui_version = '1.3.3'
+        nav_version = '2.4.2'
     }
     repositories {
         google()


### PR DESCRIPTION
This should save time with any candidate who wants to use compose navigation. This is the max version supported by this project without going through the hassle of upgrading all the other dependencies. This doesn't add any usage to the main activity so we can see whether candidates consider using it to begin with, rather than giving them the answer ahead of time.